### PR TITLE
Pull the `Spec` library from `github:savi-lang/Spec`.

### DIFF
--- a/manifest.savi
+++ b/manifest.savi
@@ -6,4 +6,5 @@
   :sources "spec/*.savi"
 
   :dependency Spec v0
+    :from "github:savi-lang/Spec"
     :depends on Map


### PR DESCRIPTION
Using no `:from` clause on a dependency is deprecated,
and all standard library packages are moving to their own repos.