### PR TITLE
Add `Map.Readable.is_empty` and `.is_not_empty` convenience methods.

### DIFF
--- a/spec/Map.Readable.Spec.savi
+++ b/spec/Map.Readable.Spec.savi
@@ -13,6 +13,21 @@
     yield map
     map
 
+  :it "knows the size of the map"
+    map = @build_map -> (map |
+      map["foo"] = 11
+      map["bar"] = 22
+      map["baz"] = 33
+    )
+    assert: map.size == 3
+    assert: map.is_empty.is_false
+    assert: map.is_not_empty
+
+    map = @build_map -> (map | None)
+    assert: map.size == 0
+    assert: map.is_empty
+    assert: map.is_not_empty.is_false
+
   :it "yields each key and each value (separately)"
     map = @build_map -> (map |
       map["foo"] = 11

--- a/src/Map.Readable.savi
+++ b/src/Map.Readable.savi
@@ -6,8 +6,15 @@
 :: of the interface can get them "for free" by inheriting the trait.
 :trait box Map.Readable(K, V)
   :fun size USize
+
   :fun has_key(key K) Bool
   :fun "[]!"(key K) @->(V'aliased)
+
+  :: Return true if the map is empty (i.e. has no key/value pairs).
+  :fun is_empty Bool: @size == 0
+
+  :: Return true if the map is non-empty (i.e. has at lease one key/value pair).
+  :fun is_not_empty Bool: @size != 0
 
   :: Yield each key and value in the map.
   :fun each None


### PR DESCRIPTION
These make for nicely natural-language-readable code.