### PR TITLE
Remove `*_until`-style iteration methods.

### DIFF
--- a/spec/Map.Ordered.Spec.savi
+++ b/spec/Map.Ordered.Spec.savi
@@ -68,30 +68,3 @@
 
     assert: keys == ["bar", "baz", "foo"]
     assert: values == [22, 55, 66]
-
-  :it "yields each key and value until the criteria is met"
-    map = @new_map
-    map["foo"] = 11
-    map["bar"] = 22
-    map["baz"] = 33
-
-    count = USize[0]
-    key = ""
-    found_it = map.each_until -> (k, v | count += 1, key = k, v == 22)
-    assert: found_it
-    assert: count == 2
-    assert: key == "bar"
-
-    count = USize[0]
-    key = ""
-    found_it = map.each_until -> (k, v | count += 1, key = k, v == 33)
-    assert: found_it
-    assert: count == 3
-    assert: key == "baz"
-
-    count = USize[0]
-    key = ""
-    found_it = map.each_until -> (k, v | count += 1, key = k, v == 99)
-    assert: count == 3
-    assert: key == "baz"
-    assert: found_it.is_false

--- a/spec/Map.Readable.Spec.savi
+++ b/spec/Map.Readable.Spec.savi
@@ -47,27 +47,6 @@
     map.each_value -> (value | total_value += value)
     assert: total_value == 66
 
-  :it "yields each key and each value (separately) until the criteria is met"
-    map = @build_map -> (map |
-      map["foo"] = 11
-      map["bar"] = 22
-      map["baz"] = 33
-    )
-
-    this_key = ""
-    found_it = map.each_key_until -> (key | this_key = key, key.ends_with("o"))
-    assert: found_it
-    assert: this_key == "foo"
-
-    this_key = ""
-    found_it = map.each_key_until -> (key | this_key = key, key.ends_with("z"))
-    assert: found_it
-    assert: this_key == "baz"
-
-    this_key = ""
-    found_it = map.each_key_until -> (key | this_key = key, key.ends_with("x"))
-    assert: found_it.is_false
-
   :it "checks if any pair in the map meets the given condition"
     map = @build_map -> (map |
       map["foo"] = 11

--- a/spec/Map.Spec.savi
+++ b/spec/Map.Spec.savi
@@ -81,23 +81,3 @@
     assert: copy["foo"]! == 11
     assert: copy["bar"]! == 22
     assert: copy["baz"]! == 33
-
-  :it "yields each key and value until the criteria is met"
-    map = @new_map
-    map["foo"] = 11
-    map["bar"] = 22
-    map["baz"] = 33
-
-    this_key = ""
-    found_it = map.each_until -> (key, value | this_key = key, value == 22)
-    assert: found_it
-    assert: this_key == "bar"
-
-    this_key = ""
-    found_it = map.each_until -> (key, value | this_key = key, value == 33)
-    assert: found_it
-    assert: this_key == "baz"
-
-    this_key = ""
-    found_it = map.each_until -> (key, value | this_key = key, value == 99)
-    assert: found_it.is_false

--- a/src/Map.Ordered.savi
+++ b/src/Map.Ordered.savi
@@ -260,21 +260,3 @@
       yield (entry.key, entry.value) // yield once more for the head
     )
     None
-
-  :: Yield each key and value in the map, in the order in they were inserted,
-  :: with the oldest key/value pairs appearing first, ending with the newest.
-  :fun each_until
-    :yields for Bool
-    early_stop = False
-    try ( // this should only fail when the map is empty, thus yielding nothing
-      head = @_head.not!(None)
-      entry = head.after!
-      while entry !== head && !early_stop (
-        early_stop = yield (entry.key, entry.value)
-        entry = entry.after!
-      )
-      if !early_stop (
-        early_stop = yield (entry.key, entry.value) // yield once more for the head
-      )
-    )
-    early_stop

--- a/src/Map.Readable.savi
+++ b/src/Map.Readable.savi
@@ -20,11 +20,6 @@
   :fun each None
     :yields (@->(K'aliased), @->(V'aliased)) for None
 
-  :: Yield each key and value in the map, stopping iteration if the yield block
-  :: returns True. Returns True if iteration was stopped early; else, False.
-  :fun each_until Bool
-    :yields (@->(K'aliased), @->(V'aliased)) for Bool
-
   :: Yield each key in the map.
   :fun each_key
     @each -> (k, v | yield k)
@@ -33,26 +28,14 @@
   :fun each_value
     @each -> (k, v | yield v)
 
-  :: Yield each key in the map, stopping iteration if the yield block
-  :: returns True. Returns True if iteration was stopped early; else, False.
-  :fun each_key_until
-    :yields for Bool
-    @each_until -> (k, v | yield k)
-
-  :: Yield each value in the map, stopping iteration if the yield block
-  :: returns True. Returns True if iteration was stopped early; else, False.
-  :fun each_value_until
-    :yields for Bool
-    @each_until -> (k, v | yield v)
-
   :: Return True after finding a key/value pair for which the yield block
   :: returns True, defaulting to False if no such key/value pair is found.
-  :fun has_any // TODO: define as simple alias of each_until?
+  :fun has_any
     :yields for Bool
-    @each_until -> (k, v | yield (k, v))
+    @each -> (k, v | has = yield (k, v), return True if has), False
 
   :: Return False after finding a key/value pair for which the yield block
   :: returns False, defaulting to True if no such key/value pair is found.
   :fun has_all
     :yields for Bool
-    @each_until -> (k, v | (yield (k, v)).not).not
+    @each -> (k, v | has = yield (k, v), return False unless has), True

--- a/src/Map.savi
+++ b/src/Map.savi
@@ -175,15 +175,3 @@
       )
     )
     None
-
-  :: Yield each key and value in the map, stopping iteration if the yield block
-  :: returns True. Returns True if iteration was stopped early; else, False.
-  :fun each_until
-    :yields for Bool
-    @_array.each_until -> (entry |
-      if entry <: @->(Pair(K, V)) (
-        yield (entry.key, entry.value)
-      |
-        False
-      )
-    )


### PR DESCRIPTION
This style/convention is a legacy from an old version of the Savi language, in which yield blocks could not be "jumped out of".

Now that `return`, `error!`, and `break` can all jump out of a yield block, the pattern (of allowing the caller to yield back a `Bool` to indicate whether iteration should continue) is obsolete, and should be removed to reduce complexity and maintenance burden.